### PR TITLE
renamed texture variable to tex to prevent opengl crash

### DIFF
--- a/shaders/display.frag
+++ b/shaders/display.frag
@@ -5,7 +5,7 @@
 
 #version 440 core
 
-layout (binding = 0) uniform sampler2D texture;
+layout (binding = 0) uniform sampler2D tex;
 
 in VertexData {
 	vec2 uv;
@@ -17,6 +17,6 @@ void main()
 {
 	//FragColor = vec4(1.0, 0.0, 0.0, 1.0);
 	//FragColor = vec4(inData.uv, 1.0, 1.0);
-	FragColor = vec4(texture(texture, inData.uv).rrr, 1);
+	FragColor = vec4(texture(tex, inData.uv).rrr, 1);
 	//FragColor = textureLod(environmentMap, inData.uv, 1.0);
 }


### PR DESCRIPTION
This crashes on my end if this variable is named "texture," renaming it to something else seems to fix it